### PR TITLE
Enable text decoration for links in CSS

### DIFF
--- a/_sass/globals/_styles.scss
+++ b/_sass/globals/_styles.scss
@@ -23,7 +23,6 @@ main {
 }
 
 a {
-    // text-decoration: none;
     color: map-get($colors, neutral-a0);
     transition: color 0.3s ease;
     &:hover { color: map-get($colors, primary-a0); }

--- a/_sass/globals/_styles.scss
+++ b/_sass/globals/_styles.scss
@@ -23,7 +23,7 @@ main {
 }
 
 a {
-    text-decoration: none;
+    // text-decoration: none;
     color: map-get($colors, neutral-a0);
     transition: color 0.3s ease;
     &:hover { color: map-get($colors, primary-a0); }


### PR DESCRIPTION
This is beneficial for accessibility reasons, as otherwise it can be hard to tell what is or isn't a link without hovering the cursor over the link.